### PR TITLE
normalizing name used for function for jade and ejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ Temper.prototype.read = function read(file) {
 Temper.prototype.prefetch = function prefetch(file, engine) {
   if (file in this.compiled) return this.compiled[file];
 
-  var name = path.basename(file, path.extname(file))
+  var name = this.normalizeName(file)
     , template = this.read(file)
     , compiled;
 
@@ -117,6 +117,23 @@ Temper.prototype.prefetch = function prefetch(file, engine) {
 
   if (!this.cache) return compiled;
   return this.compiled[file] = compiled;
+};
+
+/**
+ * Convert the filename into a safe javascript function name
+ *
+ * @param {String} file The name of the file to convert into a safe function name
+ * @returns {String} Name to use for the template function in certain supporting compilers.
+ * @api private
+ */
+Temper.prototype.normalizeName = function(file) {
+    var name = path.basename(file, path.extname(file));
+
+    // remove leading numbers
+    name = name.replace(/^[0-9]+/, '');
+
+    // remove all but alphanumeric or _ or $
+    return name.replace(/[^\w$]/g, '');
 };
 
 /**

--- a/test/temper.test.js
+++ b/test/temper.test.js
@@ -126,4 +126,19 @@ describe('temper', function () {
       expect(obj.server()).to.equal('<h1>regular</h1>');
     });
   });
+
+  describe('#normalizeName', function () {
+    it('handles filenames without special characters', function() {
+      var name = temper.normalizeName('/home/templates/template.jade');
+
+      expect(name).to.equal('template');
+    });
+
+    it('handles filenames with special characters in filenames', function() {
+      var name = temper.normalizeName('/home/templates/09$-money_$00-test.jade');
+
+      expect(name).to.equal('$money_$00test');
+    });
+
+  });
 });


### PR DESCRIPTION
Special characters in filenames cause eval errors in the browser due to invalid function names being used (in place of the default _anonymous_ name).  The use case I was hitting in particular was having hyphens in filenames.

This PR extracts that logic into `Temper.prototype.normalizeName`, which removes leading numbers, and then anything that isn't alphanumeric, a **$**, or an **_**.

A couple tests were added along with it.
