### PR TITLE
Adding debug config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,12 @@ function Temper(options) {
     ? options.cache
     : process.env.NODE_ENV !== 'production';
 
+  options.debug = 'debug' in options
+    ? options.debug
+    : process.env.NODE_ENV !== 'production';
+
   this.cache = options.cache;             // Cache compiled templates.
+  this.debug = options.debug;             // Include debug settings when compiling templates.
   this.installed = Object.create(null);   // Installed module for extension cache.
   this.required = Object.create(null);    // Template engine require cache.
   this.compiled = Object.create(null);    // Compiled template cache.
@@ -263,6 +268,7 @@ Temper.prototype.compile = function compile(template, engine, name, filename) {
 
     case 'jade':
       server = compiler.compile(template, {
+        pretty: this.debug,     // Include indentation whitespace in generated html.
         filename: filename      // Required for includes and used for debugging.
       });
 
@@ -272,7 +278,7 @@ Temper.prototype.compile = function compile(template, engine, name, filename) {
       //
       client = (compiler.compileClient || compiler.compile)(template, {
         client: true,           // Required for older Jade versions.
-        pretty: true,           // Make the code pretty by default.
+        pretty: this.debug,     // Include indentation whitespace in generated html.
         compileDebug: false,    // No debug code plx.
         filename: filename      // Required for includes and used for debugging.
       }).toString().replace('function anonymous', 'function ' + name);

--- a/test/temper.test.js
+++ b/test/temper.test.js
@@ -106,13 +106,34 @@ describe('temper', function () {
   });
 
   describe('#compile', function () {
-    it('compiles a jade template', function () {
+    it('compiles a jade template defaulting to pretty', function () {
       var obj = temper.compile('h1 hello', 'jade');
 
       expect(obj.client).to.be.a('string');
       expect(obj.library).to.be.a('string');
       expect(obj.server).to.be.a('function');
-      expect(obj.server()).to.equal('<h1>hello</h1>');
+      expect(obj.server()).to.equal('\n<h1>hello</h1>');
+    });
+
+    it('compiles a pretty jade template when debug is true', function () {
+      var temper = new Temper({ debug: true })
+        , obj = temper.compile('h1 hello\np there', 'jade');
+
+      expect(obj.client).to.be.a('string');
+      expect(obj.library).to.be.a('string');
+      expect(obj.server).to.be.a('function');
+      expect(obj.server()).to.equal('\n<h1>hello</h1>\n<p>there</p>');
+      temper.destroy();
+    });
+
+    it('compiles a minified jade template when debug is false', function () {
+      var temper = new Temper({ debug: false })
+        , obj = temper.compile('h1 hello\np there', 'jade');
+
+      expect(obj.client).to.be.a('string');
+      expect(obj.library).to.be.a('string');
+      expect(obj.server).to.be.a('function');
+      expect(obj.server()).to.equal('<h1>hello</h1><p>there</p>');
     });
 
     it('returns surrogate compiler for HTML', function () {


### PR DESCRIPTION
- Defaults to true in non-prod
- Toggles jade 'pretty' setting currently

One side effect by setting it for the server jade compilation is that it used to be `false`, but now is `true` by default.  This change is reflected in the update to the existing jade compilation test, as _pretty_ formatted templates start with a line break, so I had to account for that.  Felt a little dirty/fragile.
