### PR TITLE
Reference the first compatible template, but do no pop

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ Temper.prototype.discover = function discover(file) {
   // We couldn't find any valid template engines for the given file. Prompt the
   // user to install one of our supported template engines.
   //
-  throw new Error('No compatible template engine installed, please run: npm install --save '+ list.pop());
+  throw new Error('No compatible template engine installed, please run: npm install --save '+ list[0]);
 };
 
 /**


### PR DESCRIPTION
This fixes a case where the template not found error is reported as:

```
No compatible template engine installed, please run: npm install --save undefined
```

This is due to the `list` array in this function referencing the `Temper.prototype.supported[ext]` array which has items removed from it with the `pop` instruction.
